### PR TITLE
Allow the same gem to be installed in multiple gemsets

### DIFF
--- a/manifests/define/gem.pp
+++ b/manifests/define/gem.pp
@@ -50,14 +50,14 @@ define rvm::define::gem(
 
   ## Begin Logic
   if $ensure == 'present' {
-    exec { "rvm-gem-install-${gem_name}-${gem_version}-${ruby_version}":
+    exec { "rvm-gem-install-${gemset}-${gem_name}-${gem_version}-${ruby_version}":
       command => $gem['install'],
       unless  => $gem['lookup'],
       require => [Class['rvm'], Exec[$rvm_depency]],
     }
   }
   elsif $ensure == 'absent' {
-    exec { "rvm-gem-uninstall-${gem_name}-${gem_version}-${ruby_version}":
+    exec { "rvm-gem-uninstall-${gemset}-${gem_name}-${gem_version}-${ruby_version}":
       command => $gem['uninstall'],
       onlyif  => $gem['lookup'],
       require => [Class['rvm'], Exec[$rvm_depency]],

--- a/manifests/packages/debian.pp
+++ b/manifests/packages/debian.pp
@@ -1,26 +1,12 @@
 class rvm::packages::debian {
-
-  case $::operatingsystemrelease {
-    'wheezy/sid', /7/: {
-      $libreadline_pkg = 'libreadline-gplv2-dev'
-    }
-    default: {
-      $libreadline_pkg = 'libreadline5-dev'
+  $packages = ['build-essential', 'curl', 'gnupg', 'bash', 'gawk', 'sed',
+    'grep', 'gzip', 'bzip2', 'zlib1g-dev', 'libssl-dev',
+    'libreadline-gplv2-dev']
+  $packages.each |$package| {
+    if ! defined(Package[$package]) {
+      package { $package:
+        ensure => installed,
+      }
     }
   }
-
-  if ! defined(Package['build-essential']) { package { 'build-essential': ensure => installed } }
-  if ! defined(Package['curl'])            { package { 'curl':            ensure => installed } }
-  if ! defined(Package['gnupg'])           { package { 'gnupg':           ensure => installed } }
-  if ! defined(Package['bash'])            { package { 'bash':            ensure => installed } }
-  if ! defined(Package['gawk'])            { package { 'gawk':            ensure => installed } }
-  if ! defined(Package['sed'])             { package { 'sed':             ensure => installed } }
-  if ! defined(Package['grep'])            { package { 'grep':            ensure => installed } }
-  if ! defined(Package['gzip'])            { package { 'gzip':            ensure => installed } }
-  if ! defined(Package['bzip2'])           { package { 'bzip2':           ensure => installed } }
-  if ! defined(Package['zlib1g-dev'])      { package { 'zlib1g-dev':      ensure => installed } }
-  if ! defined(Package['libssl-dev'])      { package { 'libssl-dev':      ensure => installed } }
-  if ! defined(Package[$libreadline_pkg])  { package { $libreadline_pkg:  ensure => installed } }
-
-
 }


### PR DESCRIPTION
Also, update the Debian package management:
- All modern Debian versions uses libreadline-gplv2-dev instead of libreadline5-dev.
- Switch over to a big array of packages rather than a series of aligned `if ! defined(Package...` lines.

CC @waynr since you were the last one to work on this code.
