### PR TITLE
(MAINT) Remove deprecated options

### DIFF
--- a/files/etc/gemrc
+++ b/files/etc/gemrc
@@ -1,2 +1,2 @@
-install: --no-rdoc --no-ri
-update: --no-rdoc --no-ri
+install: --no-document
+update: --no-document

--- a/manifests/define/gem.pp
+++ b/manifests/define/gem.pp
@@ -34,14 +34,14 @@ define rvm::define::gem(
   # Setup proper install/uninstall commands based on gem version.
   if $gem_version == '' {
     $gem = {
-      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} --no-ri --no-rdoc",
+      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} --no-document",
       'uninstall' => "rvm ${rubyset_version} do gem uninstall ${gem_name}",
       'lookup'    => "rvm ${rubyset_version} do gem list | grep ${gem_name}",
     }
   }
   else {
     $gem = {
-      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} -v ${gem_version} --no-ri --no-rdoc",
+      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} -v ${gem_version} --no-document",
       'uninstall' => "rvm ${rubyset_version} do gem uninstall ${gem_name} -v ${gem_version}",
       'lookup'    => "rvm ${rubyset_version} do gem list | grep ${gem_name} | grep ${gem_version}",
     }


### PR DESCRIPTION
This commit removes command line options no-rdoc and no-ri in favor of no-document because the options have been removed from the latest versions of rvm. Prior to removal in 3.0.0 the parameters have been long deprecated. Without this change rvm cannot function on the latest versions.