### PR TITLE
Add managing /etc/rvmrc to enabled autoupdates

### DIFF
--- a/files/etc/rvmrc
+++ b/files/etc/rvmrc
@@ -1,0 +1,2 @@
+umask u=rwx,g=rwx,o=rx
+rvm_autoupdate_flag=2

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,12 @@ class rvm::config {
     source => 'puppet:///modules/rvm/etc/gemrc',
   }
 
+  file { '/etc/rvmrc':
+    ensure => file,
+    mode   => '0664',
+    source => 'puppet:///modules/rvm/etc/rvmrc',
+  }
+
   file { '/usr/local/bin/rvm_set_system_ruby':
     ensure => file,
     mode   => '0700',


### PR DESCRIPTION
Enabling autoupdates by default since we have experienced issues with installing new ruby versions due to having an outdated version of rvm installed.

Adding as a flat file for now since we should migrate off this module and decommission eventually.