### PR TITLE
(RE-15415) Add rubygems defined type

### DIFF
--- a/manifests/define/rubygems.pp
+++ b/manifests/define/rubygems.pp
@@ -1,0 +1,52 @@
+# @summary
+#   Installs a rubygems version for the specified ruby version.
+#
+#   Although RVM does support installing non-semantic versions, such as 'latest',
+#   'latest-x.y', 'head', 'master', or 'remove' (To reset to orignal version),
+#   this module does not yet support enforcing those.
+#
+# @example Ensure a specific rubygems version
+#   rvm::define::rubygems { 'ruby-3.1.3-rubygems-3.3.26':
+#     rubygems_version => '3.3.26',
+#     ruby_version     => '3.1.3',
+#   }
+#
+# @example Ensure a specific rubygems version for a named gemset
+#   rvm::define::rubygems { 'ruby-3.1.3-testing-rubygems-3.3.26':
+#     rubygems_version => '3.3.26',
+#     ruby_version     => '3.1.3',
+#     gemset           => 'testing'
+#   }
+#
+# @param ruby_version
+#   The rubygems version to install under the specified ruby_version.
+#
+# @param rubygems_version
+#   The rubygems version to install under the specified ruby_version.
+#    Valid values are a semantic version.
+#
+# @param gemset
+#   The rubygems version to install under the specified ruby_version and named gemset.
+#
+#
+define rvm::define::rubygems (
+  String[1] $ruby_version,
+  String[1] $rubygems_version,
+  Optional[String[1]] $gemset = undef,
+) {
+  if $gemset == undef {
+    $rvm_depency = "install-ruby-${ruby_version}"
+    $rubyset_version = $ruby_version
+  } else {
+    $rvm_depency = "rvm-gemset-create-${gemset}-${ruby_version}"
+    $rubyset_version = "${ruby_version}@${gemset}"
+  }
+
+  exec { "${ruby_version}-rvm-rubygems-${rubygems_version}":
+    command   => "rvm ${rubyset_version} do rvm rubygems ${rubygems_version} --force",
+    path      => '/usr/local/rvm/bin:/bin:/sbin:/usr/bin:/usr/sbin',
+    onlyif    => "sh -c '[[ $(rvm ${rubyset_version} do gem --version) != \"${rubygems_version}\" ]] || exit 1'",
+    logoutput => true,
+    require   => [Class['rvm'], Exec[$rvm_depency]],
+  }
+}


### PR DESCRIPTION
This adds the ability to enforce a rubygems version for a specified ruby version.

I specifically included the echo statement in the command so that there would be a record of the previous version of rubygems before applying, but may be better to implement as a function and fact later on.

If this looks good, then post-merge I'll look at submitting a PR for the same feature to VoxPupuli's RVM module, so that hopefully one day we can migrate to it from this legacy module.

Example idempotent upgrade:
```shell
> puppet apply site.pp
Notice: Compiled catalog for localhost in environment production in 0.12 seconds
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: Installing rubygems 3.4.10 over 3.3.26 for ruby 3.4.10
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: ruby-3.1.3 - #downloading rubygems-3.4.10
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: ruby-3.1.3 - #extracting rubygems-3.4.10......
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: ruby-3.1.3 - #removing old rubygems........
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: ruby-3.1.3 - #installing rubygems-3.4.10................
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.4.10]/returns: executed successfully
Notice: Applied catalog in 7.96 seconds

> puppet apply site.pp
Notice: Compiled catalog for localhost in environment production in 0.13 seconds
Notice: Applied catalog in 1.33 seconds
```

Example idempotent downgrade:
```shell
> puppet apply site.pp
Notice: Compiled catalog for localhost in environment production in 0.18 seconds
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: Installing rubygems 3.3.26 over 3.4.10 for ruby 3.3.26
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: ruby-3.1.3 - #downloading rubygems-3.3.26
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: ruby-3.1.3 - #extracting rubygems-3.3.26......
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: ruby-3.1.3 - #removing old rubygems........
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: ruby-3.1.3 - #installing rubygems-3.3.26.....................................
Notice: /Stage[main]/Main/Exec[3.1.3-rvm-rubygems-3.3.26]/returns: executed successfully
Notice: Applied catalog in 12.61 seconds
> puppet apply site.pp
Notice: Compiled catalog for localhost in environment production in 0.13 seconds
Notice: Applied catalog in 1.37 seconds
```