### PR TITLE
Fix the libreadline-gplv2-dev package deprecation issue for Debian GNU/Linux 11

### DIFF
--- a/manifests/packages/debian.pp
+++ b/manifests/packages/debian.pp
@@ -10,14 +10,8 @@ class rvm::packages::debian {
     'bzip2',
     'zlib1g-dev',
     'libssl-dev',
+    'libreadline-dev',
   ]
 
-  # Detect Debian version and set the appropriate readline package
-  if $facts['os']['release']['major'] >= '11' {
-    $readline_package = 'libreadline-dev'  # Use correct package for Debian 11+
-  } else {
-    $readline_package = 'libreadline-gplv2-dev'  # Older versions
-  }
-
-  ensure_packages($packages + [$readline_package], {'ensure' => 'installed'})
+  ensure_packages($packages, {'ensure' => 'installed'})
 }

--- a/manifests/packages/debian.pp
+++ b/manifests/packages/debian.pp
@@ -10,8 +10,14 @@ class rvm::packages::debian {
     'bzip2',
     'zlib1g-dev',
     'libssl-dev',
-    'libreadline-gplv2-dev',
   ]
 
-  ensure_packages($packages, {'ensure' => 'installed'})
+  # Detect Debian version and set the appropriate readline package
+  if $facts['os']['release']['major'] >= '11' {
+    $readline_package = 'libreadline-dev'  # Use correct package for Debian 11+
+  } else {
+    $readline_package = 'libreadline-gplv2-dev'  # Older versions
+  }
+
+  ensure_packages($packages + [$readline_package], {'ensure' => 'installed'})
 }


### PR DESCRIPTION
Fix the libreadline-gplv2-dev package deprecation issue for Debian GNU/Linux 11